### PR TITLE
SHA1 formulae is deprecated, use sha256 instead.

### DIFF
--- a/license.rb
+++ b/license.rb
@@ -5,7 +5,7 @@ class License < Formula
   version '0.1.1'
 
   url "https://github.com/tcnksm/license/releases/download/0.1.1/license_0.1.1_darwin_amd64.zip"
-  sha1 "388aab77fe0102064796d464739e5946152efdba"
+  sha256 "fbacecbdfa30088c32e57def5f2db721011a0b363349b1b409f7ce5de63c71a7"
 
   depends_on :arch => :intel
 


### PR DESCRIPTION
Hi @tcnksm ✋ 
While brew upgrading, the following warning occurred.

```
Warning: Calling Resource#sha1 is deprecated!
Use Resource#sha256 instead.
/usr/local/Library/Taps/tcnksm/homebrew-license/license.rb:8:in `<class:License>'
Please report this to the tcnksm/license tap!
```

I replaced sha1 with sha256 according to this message. The method of calculating the sha256 is the following command.

``` console
$ curl -sSfL https://github.com/tcnksm/license/releases/download/0.1.1/license_0.1.1_darwin_amd64.zip | shasum -a 256
fbacecbdfa30088c32e57def5f2db721011a0b363349b1b409f7ce5de63c71a7  -
```
